### PR TITLE
Make --filter optional; match all queries when omitted

### DIFF
--- a/cmd/dnstap-filter/main.go
+++ b/cmd/dnstap-filter/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -40,14 +39,11 @@ func parseCLIArgs(args []string) (cliConfig, error) {
 	if fs.NArg() > 0 {
 		return cliConfig{}, fmt.Errorf("unexpected positional arguments: %v", fs.Args())
 	}
-	if *filterExpr == "" {
-		return cliConfig{}, errors.New("required flag: --filter")
-	}
 	if countLimit < 0 {
-		return cliConfig{}, errors.New("flag --cout/-c must be >= 0")
+		return cliConfig{}, fmt.Errorf("flag --cout/-c must be >= 0")
 	}
 	if !*printFilterTree && *in == "" {
-		return cliConfig{}, errors.New("required flag: --in (or use --print-filter-tree)")
+		return cliConfig{}, fmt.Errorf("required flag: --in (or use --print-filter-tree)")
 	}
 
 	return cliConfig{

--- a/cmd/dnstap-filter/main_test.go
+++ b/cmd/dnstap-filter/main_test.go
@@ -25,10 +25,13 @@ func TestParseCLIArgs_Success(t *testing.T) {
 	}
 }
 
-func TestParseCLIArgs_RequiredFlags(t *testing.T) {
-	_, err := parseCLIArgs([]string{"--in", "in.dnstap", "--out", "out.dnstap"})
-	if err == nil {
-		t.Fatalf("expected error when --filter is missing")
+func TestParseCLIArgs_FilterOptional(t *testing.T) {
+	cfg, err := parseCLIArgs([]string{"--in", "in.dnstap", "--out", "out.dnstap"})
+	if err != nil {
+		t.Fatalf("unexpected error when --filter is omitted: %v", err)
+	}
+	if cfg.filterExpr != "" {
+		t.Fatalf("expected empty filterExpr, got: %s", cfg.filterExpr)
 	}
 }
 

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -36,7 +36,7 @@ func ParseFilterExpression(expr string) (filter.Node, error) {
 		return nil, err
 	}
 	if len(tokens) == 0 {
-		return nil, fmt.Errorf("token 0: empty expression")
+		return &filter.MatchAllNode{}, nil
 	}
 
 	p := &parser{tokens: tokens}

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -54,9 +54,19 @@ func TestParseFilterExpression_CaseInsensitiveOperators(t *testing.T) {
 	}
 }
 
+func TestParseFilterExpression_EmptyMatchesAll(t *testing.T) {
+	node, err := ParseFilterExpression("")
+	if err != nil {
+		t.Fatalf("unexpected error for empty expression: %v", err)
+	}
+	msg := newQueryMessage(t, "www.example.com.", "1.1.1.1")
+	if !node.Eval(msg) {
+		t.Fatalf("expected empty expression to match all messages")
+	}
+}
+
 func TestParseFilterExpression_Errors(t *testing.T) {
 	cases := []string{
-		"",
 		"(",
 		"foo=bar",
 		"ip=",

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -52,6 +52,12 @@ func (n *OrNode) Eval(msg dnstap.Message) bool {
 	return n.Left.Eval(msg) || n.Right.Eval(msg)
 }
 
+type MatchAllNode struct{}
+
+func (n *MatchAllNode) Eval(_ dnstap.Message) bool {
+	return true
+}
+
 func FormatTree(root Node) string {
 	return formatTree(root, 0)
 }
@@ -71,6 +77,8 @@ func formatTree(node Node, depth int) string {
 		return indent(depth) + "AND\n" + formatTree(n.Left, depth+1) + "\n" + formatTree(n.Right, depth+1)
 	case *OrNode:
 		return indent(depth) + "OR\n" + formatTree(n.Left, depth+1) + "\n" + formatTree(n.Right, depth+1)
+	case *MatchAllNode:
+		return indent(depth) + "MATCH_ALL"
 	default:
 		return indent(depth) + fmt.Sprintf("UNKNOWN %T", node)
 	}


### PR DESCRIPTION
Add MatchAllNode to filter package that always evaluates to true. When --filter is not specified, ParseFilterExpression returns a MatchAllNode so all dnstap messages pass through unfiltered.