### PR TITLE
Add not operator to filter expressions

### DIFF
--- a/README.org
+++ b/README.org
@@ -60,8 +60,8 @@ Optional:
 
 ** Filter expression
 
-Predicates can be combined with logical operators ~and~, ~or~, and ~(...)~ for grouping.
-Operator precedence: ~and~ binds tighter than ~or~; parentheses override precedence.
+Predicates can be combined with logical operators ~and~, ~or~, ~not~, and ~(...)~ for grouping.
+Operator precedence: ~not~ binds tightest, then ~and~, then ~or~; parentheses override precedence.
 Omitting ~--filter~ matches all messages.
 
 *** Predicates
@@ -171,6 +171,21 @@ Available types:
 --filter "msgtype=CLIENT_RESPONSE"
 #+end_src
 
+*** Negation (~not~)
+
+The ~not~ operator negates any predicate or grouped expression.
+
+#+begin_src sh
+# Exclude AAAA queries
+--filter "not qtype=AAAA"
+
+# Internal subnet, excluding NXDOMAIN responses
+--filter "subnet=10.0.0.0/8 and not rcode=NXDOMAIN"
+
+# Exclude a group of query types
+--filter "not (qtype=A or qtype=AAAA)"
+#+end_src
+
 ** Examples
 
 #+begin_src sh
@@ -230,6 +245,15 @@ dnstap-filter --in file:input.dnstap --filter "subnet=192.168.0.0/24 and (qtype=
 dnstap-filter --in file:input.dnstap \
   --filter "subnet=10.0.0.0/8 and suffix=example.com. and (qtype=AAAA or rcode=NXDOMAIN)"
 
+# Exclude AAAA queries
+dnstap-filter --in file:input.dnstap --filter "not qtype=AAAA"
+
+# Internal subnet, excluding NXDOMAIN
+dnstap-filter --in file:input.dnstap --filter "subnet=10.0.0.0/8 and not rcode=NXDOMAIN"
+
+# Exclude a group of query types
+dnstap-filter --in file:input.dnstap --filter "not (qtype=A or qtype=AAAA)"
+
 # Print filter tree only
 dnstap-filter --filter "ip=1.1.1.1 and (suffix=example.com. or rcode=NXDOMAIN)" --print-filter-tree
 
@@ -240,7 +264,7 @@ dnstap-filter --in file:input.dnstap --filter "suffix=example.com." --cout 100
 ** Notes
 
 - The program exits with an error at startup if the filter expression is invalid.
-- ~and~ / ~or~ operators are case-insensitive.
+- ~and~ / ~or~ / ~not~ operators are case-insensitive.
 - ~yaml:~ output is human-readable and cannot be used as input to another ~dnstap-filter~ instance.
 - File output (~file:~) supports SIGHUP for log rotation (closes and reopens the output file).
 - The legacy positional-argument CLI (~input output ip~) has been removed.

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -14,6 +14,7 @@ const (
 	tokenWord tokenType = iota
 	tokenAnd
 	tokenOr
+	tokenNot
 	tokenLParen
 	tokenRParen
 )
@@ -93,6 +94,8 @@ func tokenize(input string) ([]token, error) {
 			tokens = append(tokens, token{typ: tokenAnd, lit: word, index: tokenIndex, pos: start})
 		case strings.EqualFold(word, "or"):
 			tokens = append(tokens, token{typ: tokenOr, lit: word, index: tokenIndex, pos: start})
+		case strings.EqualFold(word, "not"):
+			tokens = append(tokens, token{typ: tokenNot, lit: word, index: tokenIndex, pos: start})
 		default:
 			tokens = append(tokens, token{typ: tokenWord, lit: word, index: tokenIndex, pos: start})
 		}
@@ -118,18 +121,29 @@ func (p *parser) parseOr() (filter.Node, error) {
 }
 
 func (p *parser) parseAnd() (filter.Node, error) {
-	left, err := p.parsePrimary()
+	left, err := p.parseNot()
 	if err != nil {
 		return nil, err
 	}
 	for p.match(tokenAnd) {
-		right, err := p.parsePrimary()
+		right, err := p.parseNot()
 		if err != nil {
 			return nil, err
 		}
 		left = &filter.AndNode{Left: left, Right: right}
 	}
 	return left, nil
+}
+
+func (p *parser) parseNot() (filter.Node, error) {
+	if p.match(tokenNot) {
+		child, err := p.parseNot()
+		if err != nil {
+			return nil, err
+		}
+		return &filter.NotNode{Child: child}, nil
+	}
+	return p.parsePrimary()
 }
 
 func (p *parser) parsePrimary() (filter.Node, error) {

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -318,6 +318,106 @@ func TestMsgtypeFilter_Invalid(t *testing.T) {
 	}
 }
 
+func TestNotOperator_Simple(t *testing.T) {
+	node, err := ParseFilterExpression("not ip=1.1.1.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if node.Eval(newQueryMessage(t, "www.example.com.", "1.1.1.1")) {
+		t.Fatalf("expected not ip=1.1.1.1 to NOT match 1.1.1.1")
+	}
+	if !node.Eval(newQueryMessage(t, "www.example.com.", "2.2.2.2")) {
+		t.Fatalf("expected not ip=1.1.1.1 to match 2.2.2.2")
+	}
+}
+
+func TestNotOperator_WithGroup(t *testing.T) {
+	node, err := ParseFilterExpression("not (ip=1.1.1.1 or ip=2.2.2.2)")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if node.Eval(newQueryMessage(t, "www.example.com.", "1.1.1.1")) {
+		t.Fatalf("expected not (ip=1.1.1.1 or ip=2.2.2.2) to NOT match 1.1.1.1")
+	}
+	if node.Eval(newQueryMessage(t, "www.example.com.", "2.2.2.2")) {
+		t.Fatalf("expected not (ip=1.1.1.1 or ip=2.2.2.2) to NOT match 2.2.2.2")
+	}
+	if !node.Eval(newQueryMessage(t, "www.example.com.", "3.3.3.3")) {
+		t.Fatalf("expected not (ip=1.1.1.1 or ip=2.2.2.2) to match 3.3.3.3")
+	}
+}
+
+func TestNotOperator_CombinedWithAnd(t *testing.T) {
+	node, err := ParseFilterExpression("suffix=example.com. and not ip=1.1.1.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if node.Eval(newQueryMessage(t, "www.example.com.", "1.1.1.1")) {
+		t.Fatalf("expected to NOT match when ip=1.1.1.1")
+	}
+	if !node.Eval(newQueryMessage(t, "www.example.com.", "2.2.2.2")) {
+		t.Fatalf("expected to match when ip=2.2.2.2 and suffix matches")
+	}
+}
+
+func TestNotOperator_DoubleNegation(t *testing.T) {
+	node, err := ParseFilterExpression("not not ip=1.1.1.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !node.Eval(newQueryMessage(t, "www.example.com.", "1.1.1.1")) {
+		t.Fatalf("expected not not ip=1.1.1.1 to match 1.1.1.1")
+	}
+	if node.Eval(newQueryMessage(t, "www.example.com.", "2.2.2.2")) {
+		t.Fatalf("expected not not ip=1.1.1.1 to NOT match 2.2.2.2")
+	}
+}
+
+func TestNotOperator_CaseInsensitive(t *testing.T) {
+	node, err := ParseFilterExpression("NOT ip=1.1.1.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if node.Eval(newQueryMessage(t, "www.example.com.", "1.1.1.1")) {
+		t.Fatalf("expected NOT to work case-insensitively")
+	}
+}
+
+func TestNotOperator_Errors(t *testing.T) {
+	cases := []string{
+		"not",
+		"not and ip=1.1.1.1",
+		"not or ip=1.1.1.1",
+	}
+
+	for _, expr := range cases {
+		_, err := ParseFilterExpression(expr)
+		if err == nil {
+			t.Fatalf("expected error for expression: %q", expr)
+		}
+	}
+}
+
+func TestFormatTree_WithNot(t *testing.T) {
+	node, err := ParseFilterExpression("not ip=1.1.1.1")
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	got := filter.FormatTree(node)
+	if !strings.Contains(got, "NOT") {
+		t.Fatalf("expected tree to contain NOT, got:\n%s", got)
+	}
+	if !strings.Contains(got, "PREDICATE ip=1.1.1.1") {
+		t.Fatalf("expected tree to contain PREDICATE ip=1.1.1.1, got:\n%s", got)
+	}
+}
+
 func newResponseMessageWithAnswers(t *testing.T, name string, ip string, answers []dns.RR) dnstap.Message {
 	t.Helper()
 

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -52,6 +52,17 @@ func (n *OrNode) Eval(msg dnstap.Message) bool {
 	return n.Left.Eval(msg) || n.Right.Eval(msg)
 }
 
+type NotNode struct {
+	Child Node
+}
+
+func (n *NotNode) Eval(msg dnstap.Message) bool {
+	if n == nil || n.Child == nil {
+		return false
+	}
+	return !n.Child.Eval(msg)
+}
+
 type MatchAllNode struct{}
 
 func (n *MatchAllNode) Eval(_ dnstap.Message) bool {
@@ -75,6 +86,8 @@ func formatTree(node Node, depth int) string {
 		return indent(depth) + "PREDICATE"
 	case *AndNode:
 		return indent(depth) + "AND\n" + formatTree(n.Left, depth+1) + "\n" + formatTree(n.Right, depth+1)
+	case *NotNode:
+		return indent(depth) + "NOT\n" + formatTree(n.Child, depth+1)
 	case *OrNode:
 		return indent(depth) + "OR\n" + formatTree(n.Left, depth+1) + "\n" + formatTree(n.Right, depth+1)
 	case *MatchAllNode:


### PR DESCRIPTION
## Changes

- **expression.go**: Added `tokenNot` token type and parsing logic
  - Tokenizer recognizes `not` keyword (case-insensitive)
  - New `parseNot()` method implements NOT operator with correct precedence (highest binding)
  - NOT can be applied to predicates and grouped expressions
  - Supports chained negation (e.g., `not not predicate`)

- **filter.go**: Added `NotNode` struct
  - Implements negation logic by inverting child node evaluation
  - Updated `formatTree()` to display NOT nodes in filter tree

- **expression_test.go**: Comprehensive test coverage
  - Simple negation tests
  - Negation with grouped expressions
  - Combination with AND/OR operators
  - Double negation support
  - Case-insensitivity validation
  - Error cases for invalid syntax
  - Tree formatting verification

- **README.org**: Updated documentation
  - Documented NOT operator and operator precedence
  - Added usage examples with practical use cases
  - Updated notes section
