### PR TITLE
Add regexp filter for query name matching

### DIFF
--- a/cmd/dnstap-filter/main.go
+++ b/cmd/dnstap-filter/main.go
@@ -39,6 +39,7 @@ func parseCLIArgs(args []string) (cliConfig, error) {
 		"\t    <IP>                   A/AAAA exact match             rdata=93.184.216.34\n"+
 		"\t    <CIDR>                 A/AAAA subnet match            rdata=10.0.0.0/8\n"+
 		"\t    <string>               TXT substring match            rdata=v=spf1\n"+
+		"\t  regexp=<pattern>       query name regexp match          regexp=\\.example\\.com\\.$\n"+
 		"\t  msgtype=<type>         dnstap message type              msgtype=CLIENT_QUERY\n"+
 		"\t    types: CLIENT_QUERY CLIENT_RESPONSE RESOLVER_QUERY RESOLVER_RESPONSE\n"+
 		"\t           AUTH_QUERY AUTH_RESPONSE FORWARDER_QUERY FORWARDER_RESPONSE\n"+

--- a/internal/expression/expression.go
+++ b/internal/expression/expression.go
@@ -226,6 +226,12 @@ func parsePredicate(tok token) (filter.Node, error) {
 			return nil, fmt.Errorf("token %d at char %d ('%s'): unknown message type %q", tok.index, tok.pos, tok.lit, value)
 		}
 		return &filter.PredicateNode{Filter: f, Key: key, Value: value}, nil
+	case "regexp":
+		f, err := filter.NewRegexpFilter(value)
+		if err != nil {
+			return nil, fmt.Errorf("token %d at char %d ('%s'): invalid regexp: %w", tok.index, tok.pos, tok.lit, err)
+		}
+		return &filter.PredicateNode{Filter: f, Key: key, Value: value}, nil
 	default:
 		return nil, fmt.Errorf("token %d at char %d ('%s'): unknown predicate key '%s'", tok.index, tok.pos, tok.lit, key)
 	}

--- a/internal/expression/expression_test.go
+++ b/internal/expression/expression_test.go
@@ -318,6 +318,47 @@ func TestMsgtypeFilter_Invalid(t *testing.T) {
 	}
 }
 
+func TestRegexpFilter_Match(t *testing.T) {
+	node, err := ParseFilterExpression(`regexp=^www\.example\.com\.$`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !node.Eval(newQueryMessage(t, "www.example.com.", "1.1.1.1")) {
+		t.Fatalf("expected regexp to match www.example.com.")
+	}
+
+	if node.Eval(newQueryMessage(t, "mail.example.com.", "1.1.1.1")) {
+		t.Fatalf("expected regexp to not match mail.example.com.")
+	}
+}
+
+func TestRegexpFilter_PartialMatch(t *testing.T) {
+	node, err := ParseFilterExpression(`regexp=\.example\.com\.$`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !node.Eval(newQueryMessage(t, "www.example.com.", "1.1.1.1")) {
+		t.Fatalf("expected regexp to match www.example.com.")
+	}
+
+	if !node.Eval(newQueryMessage(t, "mail.example.com.", "1.1.1.1")) {
+		t.Fatalf("expected regexp to match mail.example.com.")
+	}
+
+	if node.Eval(newQueryMessage(t, "www.example.org.", "1.1.1.1")) {
+		t.Fatalf("expected regexp to not match www.example.org.")
+	}
+}
+
+func TestRegexpFilter_InvalidRegexp(t *testing.T) {
+	_, err := ParseFilterExpression(`regexp=[invalid`)
+	if err == nil {
+		t.Fatalf("expected error for invalid regexp")
+	}
+}
+
 func TestNotOperator_Simple(t *testing.T) {
 	node, err := ParseFilterExpression("not ip=1.1.1.1")
 	if err != nil {

--- a/internal/filter/regexp.go
+++ b/internal/filter/regexp.go
@@ -1,0 +1,45 @@
+package filter
+
+import (
+	"regexp"
+
+	"github.com/dnstap/golang-dnstap"
+	"github.com/miekg/dns"
+)
+
+type RegexpFilter struct {
+	Re *regexp.Regexp
+}
+
+func NewRegexpFilter(pattern string) (*RegexpFilter, error) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+	return &RegexpFilter{
+		Re: re,
+	}, nil
+}
+
+func (p *RegexpFilter) Filter(m dnstap.Message) bool {
+	var msgBytes []byte
+	if m.QueryMessage != nil {
+		msgBytes = m.QueryMessage
+	} else if m.ResponseMessage != nil {
+		msgBytes = m.ResponseMessage
+	} else {
+		return false
+	}
+
+	msg := new(dns.Msg)
+	if err := msg.Unpack(msgBytes); err != nil {
+		return false
+	}
+
+	if len(msg.Question) == 0 {
+		return false
+	}
+
+	questionName := msg.Question[0].Name
+	return p.Re.MatchString(questionName)
+}


### PR DESCRIPTION
## Changes

- Add new `RegexpFilter` type in `internal/filter/regexp.go` to match query names against regular expressions
- Integrate regexp filter into expression parser to support `regexp=<pattern>` syntax
- Add comprehensive tests for regexp matching, partial matching, and invalid patterns
- Update CLI help text to document the new regexp filter option

## Details

The regexp filter extracts the query name from DNS messages and matches it against the provided regular expression pattern. This enables flexible query name filtering using standard Go regex syntax.