### PR TITLE
Add Q/R indicator and RCODE to stdout output, support stdout: scheme

### DIFF
--- a/README.org
+++ b/README.org
@@ -54,7 +54,8 @@ Specifies the destination for filtered dnstap data. The format is ~scheme:addres
 
 | Scheme | Example | Description |
 |--------|---------|-------------|
-| *(omitted)* | | Print ~<time> <name> <type>~ to stdout (default) |
+| *(omitted)* | | Print ~<time> <Q\vert{}R> <name> <type> [<rcode>]~ to stdout (default) |
+| ~stdout:<fields>~ | ~stdout:time,qr,name,type,rcode~ | Customizable stdout output (comma-separated fields) |
 | ~file:<path>~ | ~file:output.dnstap~ | Write dnstap frame stream file (supports SIGHUP log rotation) |
 | ~unix:<path>~ | ~unix:/var/run/collector.sock~ | Connect to a Unix domain socket (client mode) |
 | ~tcp:<host:port>~ | ~tcp:127.0.0.1:6001~ | Connect to a TCP collector (client mode) |
@@ -62,6 +63,34 @@ Specifies the destination for filtered dnstap data. The format is ~scheme:addres
 | ~yaml:-~ | ~yaml:-~ | Write human-readable YAML format to stdout |
 
 A bare path without a scheme (e.g. ~output.dnstap~) is treated as ~file:~ for backward compatibility.
+
+**** ~stdout:~ fields
+
+The ~stdout:~ scheme accepts a comma-separated list of field names to control which columns are printed.
+If no fields are specified (~stdout:~), the default set ~time,qr,name,type,rcode~ is used.
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| ~time~ | Timestamp (query time preferred, then response time) | ~2024-01-01 12:00:00~ |
+| ~qr~ | Query/Response indicator | ~Q~ or ~R~ |
+| ~msgtype~ | Full dnstap message type name | ~CLIENT_QUERY~ |
+| ~name~ | DNS query name | ~www.example.com.~ |
+| ~type~ | DNS query type | ~A~, ~AAAA~, ~MX~ |
+| ~rcode~ | Response code (omitted for queries) | ~NOERROR~, ~NXDOMAIN~ |
+| ~ip~ | Client IP address (QueryAddress) | ~192.168.1.1~ |
+
+#+begin_src sh
+# Default fields
+dnstap-filter --in file:input.dnstap --out stdout:
+# Output: 2024-01-01 12:00:00 Q www.example.com. A
+# Output: 2024-01-01 12:00:01 R www.example.com. A NOERROR
+
+# Custom fields: show client IP and full message type
+dnstap-filter --in file:input.dnstap --out stdout:time,msgtype,ip,name,type,rcode
+
+# Minimal: name and type only
+dnstap-filter --in file:input.dnstap --out stdout:name,type
+#+end_src
 
 Note: ~unix:~ and ~tcp:~ outputs are clients that connect to a collector. If the collector is not
 available, they retry every 10 seconds.
@@ -72,7 +101,7 @@ Required:
 - ~--in~: input spec (required unless ~--print-filter-tree~ is used)
 
 Optional:
-- ~--out~: output spec (default: print query name, type and time to stdout)
+- ~--out~: output spec (default: print ~<time> <Q|R> <name> <type> [<rcode>]~ to stdout)
 - ~--filter~: filter expression
 - ~--print-filter-tree~: print the parsed filter tree and exit
 - ~--cout~, ~-c~: process only the first N records from the beginning of input
@@ -208,9 +237,10 @@ The ~not~ operator negates any predicate or grouped expression.
 ** Examples
 
 #+begin_src sh
-# Default output: print query name, type and time to stdout
+# Default output: print time, Q/R, name, type and rcode to stdout
 dnstap-filter --in file:input.dnstap --filter "ip=1.1.1.1"
-# Output: 2024-01-15 12:34:56 example.com. A
+# Output: 2024-01-15 12:34:56 Q example.com. A
+# Output: 2024-01-15 12:34:56 R example.com. A NOERROR
 
 # Filter file to file (backward-compatible bare paths)
 dnstap-filter --in input.dnstap --out output.dnstap --filter "ip=1.1.1.1"

--- a/cmd/dnstap-filter/main.go
+++ b/cmd/dnstap-filter/main.go
@@ -26,7 +26,11 @@ func parseCLIArgs(args []string) (cliConfig, error) {
 	fs.SetOutput(os.Stderr)
 
 	in := fs.String("in", "", "input spec: file:<path> | unix:<path> | tcp:<host:port> | pcap:<path> | device:<iface>")
-	out := fs.String("out", "", "output spec: file:<path> | unix:<path> | tcp:<host:port> | yaml:<path>|yaml:-\n\t(default: print query name, type and time to stdout)")
+	out := fs.String("out", "", "output spec: file:<path> | unix:<path> | tcp:<host:port> | yaml:<path>|yaml:-\n"+
+		"\tstdout:<fields> - customizable stdout (comma-separated fields)\n"+
+		"\t  fields: time, qr, msgtype, name, type, rcode, ip\n"+
+		"\t  example: stdout:time,qr,name,type,rcode\n"+
+		"\t(default: print \"<time> <Q|R> <name> <type> [<rcode>]\" to stdout)")
 	filterExpr := fs.String("filter", "", "filter expression (omit to match all)\n"+
 		"\tPredicates:\n"+
 		"\t  ip=<addr>               DNS client IP exact match        ip=1.1.1.1\n"+

--- a/internal/transport/output.go
+++ b/internal/transport/output.go
@@ -1,10 +1,10 @@
 package transport
 
 import (
-	"bytes"
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/dnstap/golang-dnstap"
@@ -13,14 +13,211 @@ import (
 
 const defaultTimeFormat = "2006-01-02 15:04:05"
 
+// stdoutField represents a field that can be included in stdout output.
+type stdoutField int
+
+const (
+	fieldTime    stdoutField = iota // timestamp
+	fieldQR                         // Q or R indicator
+	fieldMsgType                    // full message type name (e.g. CLIENT_QUERY)
+	fieldName                       // query name
+	fieldType                       // query type (e.g. A, AAAA)
+	fieldRcode                      // response code (empty for queries)
+	fieldIP                         // client IP (QueryAddress)
+)
+
+var defaultFields = []stdoutField{fieldTime, fieldQR, fieldName, fieldType, fieldRcode}
+
+var fieldNameMap = map[string]stdoutField{
+	"time":    fieldTime,
+	"qr":      fieldQR,
+	"msgtype": fieldMsgType,
+	"name":    fieldName,
+	"type":    fieldType,
+	"rcode":   fieldRcode,
+	"ip":      fieldIP,
+}
+
+// parseStdoutFields parses a comma-separated list of field names.
+// An empty spec returns the default fields.
+func parseStdoutFields(spec string) ([]stdoutField, error) {
+	if spec == "" {
+		return defaultFields, nil
+	}
+	parts := strings.Split(spec, ",")
+	fields := make([]stdoutField, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			return nil, fmt.Errorf("empty field name in stdout spec")
+		}
+		f, ok := fieldNameMap[strings.ToLower(p)]
+		if !ok {
+			valid := make([]string, 0, len(fieldNameMap))
+			for k := range fieldNameMap {
+				valid = append(valid, k)
+			}
+			return nil, fmt.Errorf("unknown stdout field %q (valid: %s)", p, strings.Join(valid, ", "))
+		}
+		fields = append(fields, f)
+	}
+	return fields, nil
+}
+
+// isResponseType returns true if the dnstap message type is a response
+// (even enum values are responses in the protobuf definition).
+func isResponseType(mt dnstap.Message_Type) bool {
+	return int32(mt)%2 == 0
+}
+
+// newStdoutFormatFunc builds a dnstap.TextFormatFunc that outputs the
+// requested fields separated by spaces.
+func newStdoutFormatFunc(fields []stdoutField) dnstap.TextFormatFunc {
+	return func(dt *dnstap.Dnstap) ([]byte, bool) {
+		if dt.Type == nil || *dt.Type != dnstap.Dnstap_MESSAGE || dt.Message == nil {
+			return nil, false
+		}
+		m := dt.Message
+
+		// Pre-compute commonly needed values lazily.
+		var (
+			timestamp   time.Time
+			timeParsed  bool
+			dnsMsg      *dns.Msg
+			dnsMsgReady bool
+			respMsg     *dns.Msg
+			respReady   bool
+			isResp      bool
+		)
+
+		if m.Type != nil {
+			isResp = isResponseType(*m.Type)
+		}
+
+		getTime := func() time.Time {
+			if timeParsed {
+				return timestamp
+			}
+			timeParsed = true
+			if m.QueryTimeSec != nil {
+				nsec := int64(0)
+				if m.QueryTimeNsec != nil {
+					nsec = int64(*m.QueryTimeNsec)
+				}
+				timestamp = time.Unix(int64(*m.QueryTimeSec), nsec)
+			} else if m.ResponseTimeSec != nil {
+				nsec := int64(0)
+				if m.ResponseTimeNsec != nil {
+					nsec = int64(*m.ResponseTimeNsec)
+				}
+				timestamp = time.Unix(int64(*m.ResponseTimeSec), nsec)
+			}
+			return timestamp
+		}
+
+		getDNSMsg := func() *dns.Msg {
+			if dnsMsgReady {
+				return dnsMsg
+			}
+			dnsMsgReady = true
+			var msgBytes []byte
+			if m.QueryMessage != nil {
+				msgBytes = m.QueryMessage
+			} else if m.ResponseMessage != nil {
+				msgBytes = m.ResponseMessage
+			}
+			if msgBytes == nil {
+				return nil
+			}
+			msg := new(dns.Msg)
+			if err := msg.Unpack(msgBytes); err != nil {
+				return nil
+			}
+			dnsMsg = msg
+			return dnsMsg
+		}
+
+		getRespMsg := func() *dns.Msg {
+			if respReady {
+				return respMsg
+			}
+			respReady = true
+			if m.ResponseMessage == nil {
+				return nil
+			}
+			msg := new(dns.Msg)
+			if err := msg.Unpack(m.ResponseMessage); err != nil {
+				return nil
+			}
+			respMsg = msg
+			return respMsg
+		}
+
+		parts := make([]string, 0, len(fields))
+		for _, f := range fields {
+			switch f {
+			case fieldTime:
+				parts = append(parts, getTime().Format(defaultTimeFormat))
+			case fieldQR:
+				if isResp {
+					parts = append(parts, "R")
+				} else {
+					parts = append(parts, "Q")
+				}
+			case fieldMsgType:
+				if m.Type != nil {
+					parts = append(parts, dnstap.Message_Type_name[int32(*m.Type)])
+				}
+			case fieldName:
+				msg := getDNSMsg()
+				if msg == nil || len(msg.Question) == 0 {
+					return nil, false
+				}
+				parts = append(parts, msg.Question[0].Name)
+			case fieldType:
+				msg := getDNSMsg()
+				if msg == nil || len(msg.Question) == 0 {
+					return nil, false
+				}
+				parts = append(parts, dns.Type(msg.Question[0].Qtype).String())
+			case fieldRcode:
+				if !isResp {
+					continue
+				}
+				resp := getRespMsg()
+				if resp == nil {
+					continue
+				}
+				parts = append(parts, dns.RcodeToString[resp.Rcode])
+			case fieldIP:
+				if m.QueryAddress != nil {
+					parts = append(parts, net.IP(m.QueryAddress).String())
+				}
+			}
+		}
+
+		if len(parts) == 0 {
+			return nil, false
+		}
+
+		line := strings.Join(parts, " ") + "\n"
+		return []byte(line), true
+	}
+}
+
+// defaultQueryFormat implements dnstap.TextFormatFunc.
+// It renders each dnstap message as: "<time> <Q|R> <name> <type> [<rcode>]"
+var defaultQueryFormat = newStdoutFormatFunc(defaultFields)
+
 // ParseOutput parses a transport spec and returns a dnstap.Output.
 //
 // Supported schemes:
-//   - (empty)            - default: print "<time> <name> <type>" to stdout
-//   - file:<path>        - dnstap frame stream file (with SIGHUP log rotation)
-//   - unix:<path>        - Unix domain socket client (connects to a collector)
-//   - tcp:<host:port>    - TCP client (connects to a collector)
-//   - yaml:<path>|yaml:- - human-readable YAML format (- means stdout)
+//   - (empty)              - default: print "<time> <Q|R> <name> <type> [<rcode>]" to stdout
+//   - stdout:<fields>      - customizable stdout (fields: time,qr,msgtype,name,type,rcode,ip)
+//   - file:<path>          - dnstap frame stream file (with SIGHUP log rotation)
+//   - unix:<path>          - Unix domain socket client (connects to a collector)
+//   - tcp:<host:port>      - TCP client (connects to a collector)
+//   - yaml:<path>|yaml:-   - human-readable YAML format (- means stdout)
 //
 // Bare paths without a scheme are treated as file: (backward compatibility).
 func ParseOutput(spec string) (dnstap.Output, error) {
@@ -34,6 +231,12 @@ func ParseOutput(spec string) (dnstap.Output, error) {
 	}
 
 	switch u.scheme {
+	case schemeStdout:
+		fields, err := parseStdoutFields(u.address)
+		if err != nil {
+			return nil, fmt.Errorf("stdout output: %w", err)
+		}
+		return dnstap.NewTextOutput(os.Stdout, newStdoutFormatFunc(fields)), nil
 	case schemeFile:
 		return newFileOutput(u.address)
 	case schemeUnix:
@@ -53,56 +256,4 @@ func ParseOutput(spec string) (dnstap.Output, error) {
 	default:
 		return nil, fmt.Errorf("unsupported output scheme %q", u.scheme)
 	}
-}
-
-// defaultQueryFormat implements dnstap.TextFormatFunc.
-// It renders each dnstap message as a single line: "<time> <name> <type>"
-//
-// Time is taken from QueryTimeSec if present, otherwise ResponseTimeSec.
-// Name and type are taken from the first Question of the DNS message.
-func defaultQueryFormat(dt *dnstap.Dnstap) ([]byte, bool) {
-	if dt.Type == nil || *dt.Type != dnstap.Dnstap_MESSAGE || dt.Message == nil {
-		return nil, false
-	}
-	m := dt.Message
-
-	var t time.Time
-	if m.QueryTimeSec != nil {
-		nsec := int64(0)
-		if m.QueryTimeNsec != nil {
-			nsec = int64(*m.QueryTimeNsec)
-		}
-		t = time.Unix(int64(*m.QueryTimeSec), nsec)
-	} else if m.ResponseTimeSec != nil {
-		nsec := int64(0)
-		if m.ResponseTimeNsec != nil {
-			nsec = int64(*m.ResponseTimeNsec)
-		}
-		t = time.Unix(int64(*m.ResponseTimeSec), nsec)
-	}
-
-	var msgBytes []byte
-	if m.QueryMessage != nil {
-		msgBytes = m.QueryMessage
-	} else if m.ResponseMessage != nil {
-		msgBytes = m.ResponseMessage
-	}
-	if msgBytes == nil {
-		return nil, false
-	}
-
-	msg := new(dns.Msg)
-	if err := msg.Unpack(msgBytes); err != nil || len(msg.Question) == 0 {
-		return nil, false
-	}
-
-	q := msg.Question[0]
-	var s bytes.Buffer
-	s.WriteString(t.Format(defaultTimeFormat))
-	s.WriteByte(' ')
-	s.WriteString(q.Name)
-	s.WriteByte(' ')
-	s.WriteString(dns.Type(q.Qtype).String())
-	s.WriteByte('\n')
-	return s.Bytes(), true
 }

--- a/internal/transport/output_test.go
+++ b/internal/transport/output_test.go
@@ -1,0 +1,239 @@
+package transport
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/dnstap/golang-dnstap"
+	"github.com/miekg/dns"
+	"google.golang.org/protobuf/proto"
+)
+
+// buildTestDnstap constructs a dnstap message for testing.
+func buildTestDnstap(msgType dnstap.Message_Type, qname string, qtype uint16, rcode int, queryAddr net.IP) *dnstap.Dnstap {
+	dtType := dnstap.Dnstap_MESSAGE
+
+	msg := &dns.Msg{}
+	msg.SetQuestion(qname, qtype)
+	msg.Rcode = rcode
+
+	packed, err := msg.Pack()
+	if err != nil {
+		panic(err)
+	}
+
+	m := &dnstap.Message{
+		Type: &msgType,
+	}
+
+	sec := uint64(1704067200) // 2024-01-01 00:00:00 UTC
+	if isResponseType(msgType) {
+		m.ResponseTimeSec = &sec
+		m.ResponseMessage = packed
+		m.ResponseAddress = queryAddr
+	} else {
+		m.QueryTimeSec = &sec
+		m.QueryMessage = packed
+	}
+
+	if queryAddr != nil {
+		m.QueryAddress = queryAddr
+	}
+
+	return &dnstap.Dnstap{
+		Type:    &dtType,
+		Message: m,
+	}
+}
+
+func TestParseStdoutFields(t *testing.T) {
+	tests := []struct {
+		spec    string
+		want    int // expected number of fields
+		wantErr bool
+	}{
+		{"", len(defaultFields), false},
+		{"time,name,type", 3, false},
+		{"time,qr,name,type,rcode,ip,msgtype", 7, false},
+		{"bogus", 0, true},
+		{"time,,name", 0, true},
+		{"time,bogus", 0, true},
+	}
+	for _, tt := range tests {
+		fields, err := parseStdoutFields(tt.spec)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("parseStdoutFields(%q): expected error", tt.spec)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseStdoutFields(%q): unexpected error: %v", tt.spec, err)
+			continue
+		}
+		if len(fields) != tt.want {
+			t.Errorf("parseStdoutFields(%q): got %d fields, want %d", tt.spec, len(fields), tt.want)
+		}
+	}
+}
+
+func TestIsResponseType(t *testing.T) {
+	queries := []dnstap.Message_Type{
+		dnstap.Message_AUTH_QUERY,
+		dnstap.Message_RESOLVER_QUERY,
+		dnstap.Message_CLIENT_QUERY,
+		dnstap.Message_FORWARDER_QUERY,
+	}
+	responses := []dnstap.Message_Type{
+		dnstap.Message_AUTH_RESPONSE,
+		dnstap.Message_RESOLVER_RESPONSE,
+		dnstap.Message_CLIENT_RESPONSE,
+		dnstap.Message_FORWARDER_RESPONSE,
+	}
+	for _, mt := range queries {
+		if isResponseType(mt) {
+			t.Errorf("isResponseType(%v) = true, want false", mt)
+		}
+	}
+	for _, mt := range responses {
+		if !isResponseType(mt) {
+			t.Errorf("isResponseType(%v) = false, want true", mt)
+		}
+	}
+}
+
+func TestDefaultQueryFormat_Query(t *testing.T) {
+	dt := buildTestDnstap(dnstap.Message_CLIENT_QUERY, "www.example.com.", dns.TypeA, 0, nil)
+	buf, _ := proto.Marshal(dt)
+	dt2 := &dnstap.Dnstap{}
+	proto.Unmarshal(buf, dt2)
+
+	out, ok := defaultQueryFormat(dt)
+	if !ok {
+		t.Fatal("defaultQueryFormat returned false for valid query")
+	}
+	line := string(out)
+	if !strings.Contains(line, " Q ") {
+		t.Errorf("expected Q indicator in output, got: %s", line)
+	}
+	if !strings.Contains(line, "www.example.com.") {
+		t.Errorf("expected query name in output, got: %s", line)
+	}
+	if !strings.Contains(line, " A") {
+		t.Errorf("expected query type A in output, got: %s", line)
+	}
+	// Query should not have RCODE
+	if strings.Contains(line, "NOERROR") || strings.Contains(line, "NXDOMAIN") {
+		t.Errorf("query should not have RCODE in output, got: %s", line)
+	}
+}
+
+func TestDefaultQueryFormat_Response(t *testing.T) {
+	dt := buildTestDnstap(dnstap.Message_CLIENT_RESPONSE, "bad.example.com.", dns.TypeA, dns.RcodeNameError, nil)
+
+	out, ok := defaultQueryFormat(dt)
+	if !ok {
+		t.Fatal("defaultQueryFormat returned false for valid response")
+	}
+	line := string(out)
+	if !strings.Contains(line, " R ") {
+		t.Errorf("expected R indicator in output, got: %s", line)
+	}
+	if !strings.Contains(line, "bad.example.com.") {
+		t.Errorf("expected query name in output, got: %s", line)
+	}
+	if !strings.Contains(line, "NXDOMAIN") {
+		t.Errorf("expected NXDOMAIN rcode in output, got: %s", line)
+	}
+}
+
+func TestDefaultQueryFormat_ResponseNoError(t *testing.T) {
+	dt := buildTestDnstap(dnstap.Message_CLIENT_RESPONSE, "www.example.com.", dns.TypeAAAA, dns.RcodeSuccess, nil)
+
+	out, ok := defaultQueryFormat(dt)
+	if !ok {
+		t.Fatal("defaultQueryFormat returned false for valid response")
+	}
+	line := string(out)
+	if !strings.Contains(line, " R ") {
+		t.Errorf("expected R indicator in output, got: %s", line)
+	}
+	if !strings.Contains(line, "NOERROR") {
+		t.Errorf("expected NOERROR rcode in output, got: %s", line)
+	}
+}
+
+func TestNewStdoutFormatFunc_CustomFields(t *testing.T) {
+	fn := newStdoutFormatFunc([]stdoutField{fieldName, fieldType})
+	dt := buildTestDnstap(dnstap.Message_CLIENT_QUERY, "example.com.", dns.TypeMX, 0, nil)
+
+	out, ok := fn(dt)
+	if !ok {
+		t.Fatal("format func returned false")
+	}
+	line := strings.TrimSpace(string(out))
+	// Should only contain name and type, no timestamp
+	if strings.Contains(line, "2024") {
+		t.Errorf("expected no timestamp in output, got: %s", line)
+	}
+	if line != "example.com. MX" {
+		t.Errorf("expected 'example.com. MX', got: %s", line)
+	}
+}
+
+func TestNewStdoutFormatFunc_WithIP(t *testing.T) {
+	fn := newStdoutFormatFunc([]stdoutField{fieldIP, fieldName})
+	ip := net.ParseIP("192.168.1.100")
+	dt := buildTestDnstap(dnstap.Message_CLIENT_QUERY, "test.example.com.", dns.TypeA, 0, ip)
+
+	out, ok := fn(dt)
+	if !ok {
+		t.Fatal("format func returned false")
+	}
+	line := strings.TrimSpace(string(out))
+	if !strings.Contains(line, "192.168.1.100") {
+		t.Errorf("expected IP in output, got: %s", line)
+	}
+}
+
+func TestNewStdoutFormatFunc_MsgType(t *testing.T) {
+	fn := newStdoutFormatFunc([]stdoutField{fieldMsgType, fieldName})
+	dt := buildTestDnstap(dnstap.Message_RESOLVER_QUERY, "dns.example.com.", dns.TypeA, 0, nil)
+
+	out, ok := fn(dt)
+	if !ok {
+		t.Fatal("format func returned false")
+	}
+	line := strings.TrimSpace(string(out))
+	if !strings.Contains(line, "RESOLVER_QUERY") {
+		t.Errorf("expected RESOLVER_QUERY in output, got: %s", line)
+	}
+}
+
+func TestNewStdoutFormatFunc_RcodeOnQuery(t *testing.T) {
+	fn := newStdoutFormatFunc([]stdoutField{fieldName, fieldRcode})
+	dt := buildTestDnstap(dnstap.Message_CLIENT_QUERY, "example.com.", dns.TypeA, 0, nil)
+
+	out, ok := fn(dt)
+	if !ok {
+		t.Fatal("format func returned false")
+	}
+	line := strings.TrimSpace(string(out))
+	// For query, rcode should be omitted
+	if line != "example.com." {
+		t.Errorf("expected only name for query with rcode field, got: %s", line)
+	}
+}
+
+func TestDefaultQueryFormat_NilMessage(t *testing.T) {
+	dtType := dnstap.Dnstap_MESSAGE
+	dt := &dnstap.Dnstap{
+		Type:    &dtType,
+		Message: nil,
+	}
+	_, ok := defaultQueryFormat(dt)
+	if ok {
+		t.Error("expected false for nil message")
+	}
+}

--- a/internal/transport/scheme.go
+++ b/internal/transport/scheme.go
@@ -14,6 +14,7 @@ const (
 	schemeYAML   scheme = "yaml"
 	schemePcap   scheme = "pcap"
 	schemeDevice scheme = "device"
+	schemeStdout scheme = "stdout"
 )
 
 var knownSchemes = map[scheme]bool{
@@ -23,6 +24,7 @@ var knownSchemes = map[scheme]bool{
 	schemeYAML:   true,
 	schemePcap:   true,
 	schemeDevice: true,
+	schemeStdout: true,
 }
 
 type uri struct {
@@ -40,7 +42,7 @@ func parseURI(spec string) (uri, error) {
 		if knownSchemes[s] {
 			return uri{scheme: s, address: parts[1]}, nil
 		}
-		return uri{}, fmt.Errorf("unknown transport scheme %q (valid: file, unix, tcp, yaml, pcap, device)", parts[0])
+		return uri{}, fmt.Errorf("unknown transport scheme %q (valid: file, unix, tcp, yaml, pcap, device, stdout)", parts[0])
 	}
 	// No colon: treat as file path (backward compatibility).
 	return uri{scheme: schemeFile, address: spec}, nil

--- a/internal/transport/scheme_test.go
+++ b/internal/transport/scheme_test.go
@@ -73,6 +73,29 @@ func TestParseURI_YAML(t *testing.T) {
 	}
 }
 
+func TestParseURI_Stdout(t *testing.T) {
+	tests := []struct {
+		spec     string
+		wantAddr string
+	}{
+		{"stdout:", ""},
+		{"stdout:time,name,type", "time,name,type"},
+		{"stdout:time,qr,name,type,rcode,ip", "time,qr,name,type,rcode,ip"},
+	}
+	for _, tt := range tests {
+		u, err := parseURI(tt.spec)
+		if err != nil {
+			t.Fatalf("parseURI(%q) error: %v", tt.spec, err)
+		}
+		if u.scheme != schemeStdout {
+			t.Fatalf("parseURI(%q): expected scheme stdout, got %q", tt.spec, u.scheme)
+		}
+		if u.address != tt.wantAddr {
+			t.Fatalf("parseURI(%q): expected address %q, got %q", tt.spec, tt.wantAddr, u.address)
+		}
+	}
+}
+
 func TestParseURI_UnknownScheme(t *testing.T) {
 	_, err := parseURI("ftp:some.server")
 	if err == nil {


### PR DESCRIPTION
## Changes

- **Enhanced default stdout output** to include Query/Response indicator (Q or R) and response code (RCODE)
  - Format changed from `<time> <name> <type>` to `<time> <Q|R> <name> <type> [<rcode>]`
  - RCODE only shown for responses

- **New `stdout:` output scheme** with customizable field selection
  - Supports comma-separated field list: `stdout:time,qr,name,type,rcode,ip,msgtype`
  - Empty spec uses default fields: `stdout:` → time, qr, name, type, rcode
  - Available fields: time, qr, msgtype, name, type, rcode, ip

- **Refactored stdout formatting logic**
  - Replaced simple `defaultQueryFormat` function with `newStdoutFormatFunc` factory
  - Added `parseStdoutFields()` to parse and validate field specifications
  - Implemented lazy evaluation of expensive operations (DNS message parsing, timestamp extraction)
  - Added `isResponseType()` helper to distinguish queries from responses

- **Comprehensive test coverage** with new `output_test.go`
  - Tests for field parsing, response type detection, and format output
  - Tests for custom field combinations and edge cases

- **Updated documentation** in README with field descriptions, examples, and use cases
- **Updated CLI help text** with new stdout scheme details